### PR TITLE
refactor: Change `NbtAsJsonTextComponentSerializer`'s serial descriptor.

### DIFF
--- a/datapackDSL/src/main/kotlin/serializers/NbtAsJsonTextComponentSerializer.kt
+++ b/datapackDSL/src/main/kotlin/serializers/NbtAsJsonTextComponentSerializer.kt
@@ -1,9 +1,6 @@
 package serializers
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.serialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
@@ -13,8 +10,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import net.benwoodworth.knbt.*
 
 object NbtAsJsonTextComponentSerializer : KSerializer<NbtTag> {
-	@OptIn(ExperimentalSerializationApi::class)
-	override val descriptor = SerialDescriptor("TextComponentJsonSerializer", serialDescriptor<JsonElement>())
+	override val descriptor = JsonElement.serializer().descriptor
 	
 	override fun serialize(encoder: Encoder, value: NbtTag) = encoder.encodeSerializableValue(JsonElement.serializer(), value.toJsonElement())
 	


### PR DESCRIPTION
It's a small change, but probably more "correct", and may let the `Json` serializer handle the data more effectively (since it now knows it's receiving plain old `JsonElement`s :raised_hands:

- More closely follows kotlinx.serialization's surrogate serializer example.
- Also removes the need for `@ExperimentalSerializationApi`.

https://github.com/Kotlin/kotlinx.serialization/blob/v1.4.1/docs/serializers.md#composite-serializer-via-surrogate

> We can use the same approach as in delegating serializer, but
  this time, we are fully reusing an automatically generated
  SerialDescriptor for the surrogate because it should be
  indistinguishable from the original.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>