### PR TITLE
Fix bindings generation for datapacks with dots in namespace

### DIFF
--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/Configuration.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/Configuration.kt
@@ -49,9 +49,66 @@ class DatapackConfiguration {
 	/**
 	 * Override the generated Kotlin object name.
 	 */
-	var remappedName: String? = null
+	@Deprecated("Use remappings { objectName(...) } instead", level = DeprecationLevel.WARNING)
+	var remappedName: String?
+		get() = remappings.objectName
+		set(value) = if (value != null) remappings.objectName(value) else Unit
 	/**
 	 * Select a subfolder within the downloaded datapack.
 	 */
 	var subPath: String? = null
+
+	/**
+	 * Configuration for remapping namespaces within this datapack.
+	 */
+	internal val remappings = RemappingConfiguration()
+
+	/**
+	 * Configures namespace remappings for this datapack.
+	 */
+	fun remappings(block: RemappingConfiguration.() -> Unit) = remappings.apply(block)
+}
+
+/**
+ * Configuration for remapping namespaces within a datapack.
+ */
+class RemappingConfiguration {
+	/**
+	 * Map of namespace names to their remapped names.
+	 */
+	internal val namespaces = mutableMapOf<String, String>()
+
+	/**
+	 * Override the generated Kotlin object name.
+	 */
+	var objectName: String? = null
+
+	/**
+	 * Checks if any remappings have been configured.
+	 */
+	fun hasRemappings() = namespaces.isNotEmpty() || objectName != null
+
+	/**
+	 * Renames the generated Kotlin object.
+	 */
+	fun objectName(name: String) {
+		objectName = name
+	}
+
+	/**
+	 * Remaps a namespace to a new name.
+	 */
+	fun namespace(namespace: String, remappedName: String) {
+		namespaces[namespace] = remappedName
+	}
+
+	/**
+	 * Infix function to remap a namespace to a new name.
+	 * Usage: `"old_namespace" namespaceRemapTo "new_namespace"`
+	 */
+	infix fun String.namespaceRemapTo(remappedName: String) {
+		namespaces[this] = remappedName
+	}
+
+	internal fun toState() = RemappingState(namespaces.toMap(), objectName)
 }

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/Configuration.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/Configuration.kt
@@ -54,15 +54,13 @@ class DatapackConfiguration {
 		get() = remappings.objectName
 		set(value) = if (value != null) remappings.objectName(value) else Unit
 	/**
-	 * Select a subfolder within the downloaded datapack.
-	 */
-	var subPath: String? = null
-
-	/**
 	 * Configuration for remapping namespaces within this datapack.
 	 */
 	internal val remappings = RemappingConfiguration()
-
+	/**
+	 * Select a subfolder within the downloaded datapack.
+	 */
+	var subPath: String? = null
 	/**
 	 * Configures namespace remappings for this datapack.
 	 */
@@ -89,13 +87,6 @@ class RemappingConfiguration {
 	fun hasRemappings() = namespaces.isNotEmpty() || objectName != null
 
 	/**
-	 * Renames the generated Kotlin object.
-	 */
-	fun objectName(name: String) {
-		objectName = name
-	}
-
-	/**
 	 * Remaps a namespace to a new name.
 	 */
 	fun namespace(namespace: String, remappedName: String) {
@@ -103,11 +94,10 @@ class RemappingConfiguration {
 	}
 
 	/**
-	 * Infix function to remap a namespace to a new name.
-	 * Usage: `"old_namespace" namespaceRemapTo "new_namespace"`
+	 * Renames the generated Kotlin object.
 	 */
-	infix fun String.namespaceRemapTo(remappedName: String) {
-		namespaces[this] = remappedName
+	fun objectName(name: String) {
+		objectName = name
 	}
 
 	internal fun toState() = RemappingState(namespaces.toMap(), objectName)

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImport.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImport.kt
@@ -120,9 +120,6 @@ class DatapackImportDsl {
 		if (datapackConfig.packageName != null) {
 			importer.packageNameOverride = datapackConfig.packageName!!
 		}
-		if (datapackConfig.remappedName != null) {
-			importer.remappedNameOverride = datapackConfig.remappedName!!
-		}
 		if (datapackConfig.subPath != null) {
 			importer.subPath = datapackConfig.subPath!!
 		}
@@ -131,6 +128,9 @@ class DatapackImportDsl {
 		}
 		if (datapackConfig.excludes.isNotEmpty()) {
 			importer.excludes = datapackConfig.excludes
+		}
+		if (datapackConfig.remappings.hasRemappings()) {
+			importer.remappings = datapackConfig.remappings.toState()
 		}
 
 		// If no custom package name, use global prefix with datapack name

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporter.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporter.kt
@@ -18,9 +18,9 @@ internal class DatapackImporter(val source: String) {
 	var includes: List<String> = emptyList()
 	var outputDirectory: Path? = null
 	var packageNameOverride: String? = null
-	var remappedNameOverride: String? = null
 	var skipCache: Boolean = false
 	var subPath: String? = null
+	var remappings: RemappingState = RemappingState(emptyMap(), null)
 
 	/**
 	 * Sets the output directory for generated Kotlin code.
@@ -69,6 +69,11 @@ internal class DatapackImporter(val source: String) {
 	 */
 	fun write(datapack: Datapack) {
 		val outputPath = outputDirectory ?: Path("src/main/kotlin")
-		generateDatapackFile(datapack, outputPath, packageNameOverride, remappedNameOverride)
+		generateDatapackFile(datapack, outputPath, packageNameOverride, remappings)
 	}
 }
+
+class RemappingState(
+	val namespaces: Map<String, String> = emptyMap(),
+	val objectName: String? = null
+)

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporter.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporter.kt
@@ -18,9 +18,9 @@ internal class DatapackImporter(val source: String) {
 	var includes: List<String> = emptyList()
 	var outputDirectory: Path? = null
 	var packageNameOverride: String? = null
+	var remappings: RemappingState = RemappingState(emptyMap(), null)
 	var skipCache: Boolean = false
 	var subPath: String? = null
-	var remappings: RemappingState = RemappingState(emptyMap(), null)
 
 	/**
 	 * Sets the output directory for generated Kotlin code.

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
@@ -4,6 +4,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import io.github.ayfri.kore.bindings.api.RemappingState
 import io.github.ayfri.kore.bindings.generation.*
 import java.net.URLDecoder
 import java.nio.file.Files
@@ -14,7 +15,7 @@ import kotlin.io.path.absolute
  * Main entry point for generating Kotlin bindings from a datapack.
  * Normalizes the datapack name and delegates to generateDatapackFile.
  */
-fun writeFiles(datapack: Datapack, outputPath: Path) {
+fun writeFiles(datapack: Datapack, outputPath: Path, remappings: RemappingState = RemappingState()) {
 	val baseName = datapack.name.removeSuffix(".zip")
 	// Decode URL-encoded characters and remove invalid characters
 	val decodedName = URLDecoder.decode(baseName, "UTF-8")
@@ -22,15 +23,19 @@ fun writeFiles(datapack: Datapack, outputPath: Path) {
 		.replace(".", "-")
 		.replace(Regex("[^a-zA-Z0-9_-]"), "")
 	val packageName = "kore.dependencies.${normalizedName.lowercase().replace(Regex("[^a-z0-9]"), "")}"
+	val remappings = RemappingState(
+		namespaces = remappings.namespaces,
+		objectName = remappings.objectName ?: normalizedName
+	)
 
-	generateDatapackFile(datapack, outputPath, packageName, normalizedName)
+	generateDatapackFile(datapack, outputPath, packageName, remappings)
 }
 
 /**
  * Generates the main datapack Kotlin file with all resources.
  * Creates a single data object containing all functions, resources, and pack metadata.
  */
-fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverride: String? = null, normalizedNameOverride: String? = null) {
+fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverride: String? = null, remappings: RemappingState) {
 	// Decode and normalize the datapack name
 	val baseName = datapack.name.removeSuffix(".zip")
 	val decodedName = try {
@@ -39,7 +44,7 @@ fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverrid
 		baseName // If decoding fails, use the original name
 	}
 
-	val normalizedName = normalizedNameOverride ?: decodedName
+	val normalizedName = remappings.objectName ?: decodedName
 		.replace(".", "-")
 		.replace(Regex("[^a-zA-Z0-9_-]"), "")
 
@@ -143,8 +148,8 @@ fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverrid
 			} else {
 				// Multiple namespaces - create intermediate objects for each namespace
 				allNamespaces.forEach { namespace ->
-					val namespaceObjectName = namespace
-						.replace(".", "_")
+					val namespaceObjectName = remappings.namespaces[namespace] ?: namespace
+						.replace(Regex("[^a-zA-Z0-9_]"), "_")
 						.pascalCase()
 					val namespaceObject = TypeSpec.objectBuilder(namespaceObjectName)
 						.addModifiers(KModifier.DATA)

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
@@ -143,7 +143,9 @@ fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverrid
 			} else {
 				// Multiple namespaces - create intermediate objects for each namespace
 				allNamespaces.forEach { namespace ->
-					val namespaceObjectName = namespace.pascalCase()
+					val namespaceObjectName = namespace
+						.replace(".", "_")
+						.pascalCase()
 					val namespaceObject = TypeSpec.objectBuilder(namespaceObjectName)
 						.addModifiers(KModifier.DATA)
 						.addProperty(

--- a/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
+++ b/bindings/src/main/kotlin/io/github/ayfri/kore/bindings/writer.kt
@@ -23,19 +23,19 @@ fun writeFiles(datapack: Datapack, outputPath: Path, remappings: RemappingState 
 		.replace(".", "-")
 		.replace(Regex("[^a-zA-Z0-9_-]"), "")
 	val packageName = "kore.dependencies.${normalizedName.lowercase().replace(Regex("[^a-z0-9]"), "")}"
-	val remappings = RemappingState(
+	val actualRemappings = RemappingState(
 		namespaces = remappings.namespaces,
 		objectName = remappings.objectName ?: normalizedName
 	)
 
-	generateDatapackFile(datapack, outputPath, packageName, remappings)
+	generateDatapackFile(datapack, outputPath, packageName, actualRemappings)
 }
 
 /**
  * Generates the main datapack Kotlin file with all resources.
  * Creates a single data object containing all functions, resources, and pack metadata.
  */
-fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverride: String? = null, remappings: RemappingState) {
+fun generateDatapackFile(datapack: Datapack, outputDir: Path, packageNameOverride: String? = null, remappings: RemappingState = RemappingState()) {
 	// Decode and normalize the datapack name
 	val baseName = datapack.name.removeSuffix(".zip")
 	val decodedName = try {

--- a/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/Main.kt
+++ b/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/Main.kt
@@ -15,5 +15,6 @@ fun main() {
 	dungeonsAndTavernsTests()
 	tagsTests()
 	downloadTests()
+	writerTests()
 	println("All tests passed!")
 }

--- a/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/WriterTests.kt
+++ b/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/WriterTests.kt
@@ -1,0 +1,163 @@
+package io.github.ayfri.kore.bindings
+
+import io.github.ayfri.kore.bindings.api.RemappingState
+import io.github.ayfri.kore.commands.say
+import io.github.ayfri.kore.features.advancements.advancement
+import io.github.ayfri.kore.features.advancements.criteria
+import io.github.ayfri.kore.features.advancements.triggers.tick
+import io.github.ayfri.kore.functions.function
+import kotlin.io.path.readText
+
+fun writerTests() {
+	testNamespaceWithDotsInMultiNamespace()
+	testNamespaceWithHyphensInMultiNamespace()
+	testNamespaceWithMixedSpecialCharsInMultiNamespace()
+	testNamespaceRemappingRenamesObject()
+	testObjectNameAndNamespaceRemappingCombined()
+}
+
+fun testNamespaceWithDotsInMultiNamespace() = newTest("ns_normalize_dots") {
+	val pack = createDataPack("ns_normalize_dots") {
+		function("fn1", namespace = "my.ns.one") { say("1") }
+		function("fn2", namespace = "my.ns.two") { say("2") }
+	}
+
+	pack.generate()
+
+	val explored = explore(pack.path.toString())
+	val srcDir = srcDir()
+	writeFiles(explored, srcDir)
+
+	val content = srcDir.resolve("NsNormalizeDots.kt").readText()
+
+	// Dots are valid in Minecraft namespaces but not in Kotlin identifiers, writer must normalize them
+	content.contains("data object my.ns.one") assertsIs false
+	content.contains("data object my.ns.two") assertsIs false
+	content.contains("data object MyNsOne") assertsIs true
+	content.contains("data object MyNsTwo") assertsIs true
+}
+
+fun testNamespaceWithHyphensInMultiNamespace() = newTest("ns_normalize_hyphens") {
+	val pack = createDataPack("ns_normalize_hyphens") {
+		function("fn1", namespace = "some-ns") { say("1") }
+		function("fn2", namespace = "another-ns") { say("2") }
+	}
+
+	pack.generate()
+
+	val explored = explore(pack.path.toString())
+	val srcDir = srcDir()
+	writeFiles(explored, srcDir)
+
+	val content = srcDir.resolve("NsNormalizeHyphens.kt").readText()
+
+	// Hyphens are valid in Minecraft namespaces but not in Kotlin identifiers, writer must normalize them
+	content.contains("data object some-ns") assertsIs false
+	content.contains("data object another-ns") assertsIs false
+	content.contains("data object SomeNs") assertsIs true
+	content.contains("data object AnotherNs") assertsIs true
+}
+
+fun testNamespaceWithMixedSpecialCharsInMultiNamespace() = newTest("ns_normalize_mixed") {
+	val pack = createDataPack("ns_normalize_mixed") {
+		function("fn1", namespace = "foo.bar-baz_qux") { say("a") }
+		function("fn2", namespace = "hello.world") { say("b") }
+	}
+
+	pack.generate()
+
+	val explored = explore(pack.path.toString())
+	val srcDir = srcDir()
+	writeFiles(explored, srcDir)
+
+	val content = srcDir.resolve("NsNormalizeMixed.kt").readText()
+
+	content.contains("data object foo.bar-baz_qux") assertsIs false
+	content.contains("data object hello.world") assertsIs false
+	content.contains("data object FooBarBazQux") assertsIs true
+	content.contains("data object HelloWorld") assertsIs true
+}
+
+fun testNamespaceRemappingRenamesObject() = newTest("remapping_namespace") {
+	val pack = createDataPack("remap_ns_test") {
+		function("fn1", namespace = "internal_ns") { say("1") }
+		function("fn2", namespace = "other_ns") { say("2") }
+	}
+
+	pack.generate()
+
+	val explored = explore(pack.path.toString())
+	val srcDir = srcDir()
+
+	writeFiles(
+		explored,
+		srcDir,
+		RemappingState(
+			namespaces = mapOf(
+				"internal_ns" to "PublicApi",
+				"other_ns" to "PrivateImpl",
+			)
+		)
+	)
+
+	val content = srcDir.resolve("RemapNsTest.kt").readText()
+
+	content.contains("data object PublicApi") assertsIs true
+	content.contains("data object PrivateImpl") assertsIs true
+
+	// Default PascalCase-of-namespace names must not appear
+	content.contains("data object InternalNs") assertsIs false
+	content.contains("data object OtherNs") assertsIs false
+
+	// NAMESPACE constants must still hold the original namespace strings
+	val publicApiSection = content.substringAfter("data object PublicApi")
+	publicApiSection.contains("const val NAMESPACE: String = \"internal_ns\"") assertsIs true
+
+	val privateImplSection = content.substringAfter("data object PrivateImpl")
+	privateImplSection.contains("const val NAMESPACE: String = \"other_ns\"") assertsIs true
+}
+
+fun testObjectNameAndNamespaceRemappingCombined() = newTest("remapping_combined") {
+	val pack = createDataPack("combined_remap") {
+		function("fn1", namespace = "ns_a") { say("a") }
+		function("fn2", namespace = "ns_b") { say("b") }
+
+		advancement("adv1") {
+			namespace = "ns_a"
+			criteria { tick("test") }
+		}
+	}
+
+	pack.generate()
+
+	val explored = explore(pack.path.toString())
+	val srcDir = srcDir()
+
+	writeFiles(
+		explored,
+		srcDir,
+		RemappingState(
+			namespaces = mapOf("ns_a" to "CoreFeatures", "ns_b" to "CompatLayer"),
+			objectName = "MyDatapack"
+		)
+	)
+
+	val generatedFile = srcDir.resolve("MyDatapack.kt")
+	generatedFile.toFile().exists() assertsIs true
+
+	val content = generatedFile.readText()
+
+	content.contains("data object MyDatapack") assertsIs true
+	content.contains("data object CoreFeatures") assertsIs true
+	content.contains("data object CompatLayer") assertsIs true
+	content.contains("data object NsA") assertsIs false
+	content.contains("data object NsB") assertsIs false
+	content.contains("data object CombinedRemap") assertsIs false
+
+	// NAMESPACE constants must preserve the original namespace strings
+	val coreFeaturesSection = content.substringAfter("data object CoreFeatures")
+	coreFeaturesSection.contains("const val NAMESPACE: String = \"ns_a\"") assertsIs true
+
+	val compatLayerSection = content.substringAfter("data object CompatLayer")
+	compatLayerSection.contains("const val NAMESPACE: String = \"ns_b\"") assertsIs true
+}

--- a/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporterTests.kt
+++ b/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/api/DatapackImporterTests.kt
@@ -119,7 +119,7 @@ fun testCustomRemapName() = newTest("custom_remap") {
 		}
 
 		url(pack.path.toString()) {
-			remappedName = "MyCustomName"
+			remappings { objectName("MyCustomName") }
 		}
 	}
 
@@ -219,7 +219,7 @@ fun testMixedConfiguration() = newTest("mixed_config") {
 		}
 
 		url(pack1.path.toString()) {
-			remappedName = "FirstPack"
+			remappings { objectName("FirstPack") }
 		}
 
 		url(pack2.path.toString()) {

--- a/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/dungeonsAndTaverns.kt
+++ b/bindings/src/test/kotlin/io/github/ayfri/kore/bindings/dungeonsAndTaverns.kt
@@ -1,6 +1,5 @@
 package io.github.ayfri.kore.bindings
 
-import io.github.ayfri.kore.bindings.*
 import io.github.ayfri.kore.bindings.api.importDatapacks
 
 fun dungeonsAndTavernsTests() = newTest("dungeonsAndTaverns") {

--- a/website/src/jsMain/resources/markdown/doc/advanced/Bindings.md
+++ b/website/src/jsMain/resources/markdown/doc/advanced/Bindings.md
@@ -5,7 +5,7 @@ nav-title: Bindings
 description: Import existing datapacks and generate Kotlin bindings.
 keywords: kore, bindings, import, datapack, github, modrinth, curseforge
 date-created: 2026-01-23
-date-modified: 2026-02-03
+date-modified: 2026-02-25
 routeOverride: /docs/advanced/bindings
 position: 3
 ---
@@ -204,13 +204,28 @@ Defined in the block following a source:
 
 ```kotlin
 github("user.repo") {
-	remappedName = "MyPack"       // Change the generated object name
 	packageName = "custom.pkg"    // Change the package for this pack
 	subPath = "datapacks/main"    // Only import from this subfolder
 	includes = listOf("data/**")  // Only include files matching these patterns
 	excludes = listOf("**/test/**") // Exclude files matching these patterns
+
+	remappings {
+		objectName("MyPack")                           // Change the generated object name
+		namespace("old_namespace", "NewNamespace")     // Rename a specific namespace object
+		"another_ns" namespaceRemapTo "BetterName"     // Infix syntax for namespace renaming
+	}
 }
 ```
+
+> [!NOTE]
+> The `remappedName` property is deprecated. Use `remappings { objectName("...") }` instead.
+
+### Namespace normalization
+
+Namespace names are automatically normalized when generating Kotlin object names: dots (`.`) and other
+non-alphanumeric characters are replaced with underscores, then converted to PascalCase. For example,
+`my.namespace` becomes `MyNamespace`. You can override this behaviour for any namespace using the
+`remappings {}` block described above.
 
 ## Cache
 

--- a/website/src/jsMain/resources/markdown/doc/advanced/Bindings.md
+++ b/website/src/jsMain/resources/markdown/doc/advanced/Bindings.md
@@ -5,7 +5,7 @@ nav-title: Bindings
 description: Import existing datapacks and generate Kotlin bindings.
 keywords: kore, bindings, import, datapack, github, modrinth, curseforge
 date-created: 2026-01-23
-date-modified: 2026-02-25
+date-modified: 2026-03-04
 routeOverride: /docs/advanced/bindings
 position: 3
 ---
@@ -212,7 +212,6 @@ github("user.repo") {
 	remappings {
 		objectName("MyPack")                           // Change the generated object name
 		namespace("old_namespace", "NewNamespace")     // Rename a specific namespace object
-		"another_ns" namespaceRemapTo "BetterName"     // Infix syntax for namespace renaming
 	}
 }
 ```
@@ -224,7 +223,7 @@ github("user.repo") {
 
 Namespace names are automatically normalized when generating Kotlin object names: dots (`.`) and other
 non-alphanumeric characters are replaced with underscores, then converted to PascalCase. For example,
-`my.namespace` becomes `MyNamespace`. You can override this behaviour for any namespace using the
+`my.namespace` becomes `MyNamespace`. You can override this behavior for any namespace using the
 `remappings {}` block described above.
 
 ## Cache


### PR DESCRIPTION
The original code was causing the following crash:
 ```
Exception in thread "main" java.lang.IllegalArgumentException: Can't escape identifier `Bs.bitwise` because it contains illegal characters: .
	at com.squareup.kotlinpoet.UtilKt.failIfEscapeInvalid(Util.kt:277)
	at com.squareup.kotlinpoet.UtilKt.escapeIfNecessary(Util.kt:287)
	at com.squareup.kotlinpoet.UtilKt.escapeIfNecessary$default(Util.kt:283)
	at com.squareup.kotlinpoet.CodeBlock$Builder.addArgument(CodeBlock.kt:346)
	at com.squareup.kotlinpoet.CodeBlock$Builder.add(CodeBlock.kt:322)
	at com.squareup.kotlinpoet.CodeBlock$Companion.of(CodeBlock.kt:489)
	at com.squareup.kotlinpoet.CodeWriter.emitCode(CodeWriter.kt:268)
	at com.squareup.kotlinpoet.TypeSpec.emit$kotlinpoet(TypeSpec.kt:180)
	at com.squareup.kotlinpoet.TypeSpec.emit$kotlinpoet(TypeSpec.kt:327)
	at com.squareup.kotlinpoet.TypeSpec.emit$kotlinpoet$default(TypeSpec.kt:111)
	at com.squareup.kotlinpoet.FileSpec.emit(FileSpec.kt:201)
	at com.squareup.kotlinpoet.FileSpec.writeTo$lambda$2(FileSpec.kt:88)
	at com.squareup.kotlinpoet.CodeWriter$Companion.withCollectedImports(CodeWriter.kt:752)
	at com.squareup.kotlinpoet.FileSpec.writeTo(FileSpec.kt:84)
	at com.squareup.kotlinpoet.FileSpec.toString(FileSpec.kt:222)
	at io.github.ayfri.kore.bindings.WriterKt.generateDatapackFile(writer.kt:214)
	at io.github.ayfri.kore.bindings.api.DatapackImporter.write(DatapackImporter.kt:72)
	at io.github.ayfri.kore.bindings.api.DatapackImportDsl.execute$bindings(DatapackImport.kt:144)
	at io.github.ayfri.kore.bindings.api.DatapackImportKt.importDatapacks(DatapackImport.kt:181)
```

When working with a datapack that uses a dot as part of its namespace (here `bs.bitwise` from [Bookshelf](https://mcbookshelf.dev/)). To prevent it, dots are replaced by underscores.