### PR TITLE
feat(advancement): Add player interact with entity trigger

### DIFF
--- a/kore/src/main/kotlin/io/github/ayfri/kore/commands/execute/ExecuteClass.kt
+++ b/kore/src/main/kotlin/io/github/ayfri/kore/commands/execute/ExecuteClass.kt
@@ -36,6 +36,7 @@ enum class Relation {
 	CONTROLLER,
 	LEASHER,
 	OWNER,
+	ORIGIN,
 	PASSENGERS,
 	TARGET,
 	VEHICLE;

--- a/kore/src/main/kotlin/io/github/ayfri/kore/features/advancements/triggers/PlayerInteractedWithEntity.kt
+++ b/kore/src/main/kotlin/io/github/ayfri/kore/features/advancements/triggers/PlayerInteractedWithEntity.kt
@@ -1,0 +1,34 @@
+package io.github.ayfri.kore.features.advancements.triggers
+
+import io.github.ayfri.kore.features.advancements.AdvancementCriteria
+import io.github.ayfri.kore.features.advancements.EntityOrPredicates
+import io.github.ayfri.kore.features.predicates.sub.ItemStack
+import kotlinx.serialization.Serializable
+
+/**
+ * Triggered when a player interacts with an entity.
+ *
+ * Docs: https://kore.ayfri.com/docs/data-driven/advancements/triggers#playerinteractedwithentity
+ * Minecraft Wiki: https://minecraft.wiki/w/Advancement/JSON_format
+ */
+@Serializable
+data class PlayerInteractedWithEntity(
+	override var player: EntityOrPredicates? = null,
+	var item: ItemStack? = null,
+	var entity: EntityOrPredicates? = null,
+) : AdvancementTriggerCondition()
+
+/** Add a `playerInteractedWithEntity` criterion, triggered when a player interacts with an entity. */
+fun AdvancementCriteria.playerInteractedWithEntity(name: String, block: PlayerInteractedWithEntity.() -> Unit = {}) {
+	criteria[name] = PlayerInteractedWithEntity().apply(block)
+}
+
+/** Set the item constraints. */
+fun PlayerInteractedWithEntity.item(block: ItemStack.() -> Unit) {
+	item = ItemStack().apply(block)
+}
+
+/** Set the entity constraints. */
+fun PlayerInteractedWithEntity.entity(block: EntityOrPredicates.() -> Unit) {
+	entity = EntityOrPredicates().apply(block)
+}

--- a/kore/src/test/kotlin/io/github/ayfri/kore/features/AdvancementTests.kt
+++ b/kore/src/test/kotlin/io/github/ayfri/kore/features/AdvancementTests.kt
@@ -921,6 +921,38 @@ private fun DataPack.allTriggersTests() {
 		}
 	""".trimIndent()
 
+	advancement("player_interacted_with_entity") {
+		criteria {
+			playerInteractedWithEntity("example") {
+				item {
+					items = listOf(Items.IRON_INGOT)
+				}
+				entity {
+					conditionEntity {
+						type(EntityTypes.IRON_GOLEM)
+					}
+				}
+			}
+		}
+	}
+	advancements.last() assertsIs """
+		{
+			"criteria": {
+				"example": {
+					"trigger": "minecraft:player_interacted_with_entity",
+					"conditions": {
+						"item": {
+							"items": "minecraft:iron_ingot"
+						},
+						"entity": {
+							"type": "minecraft:iron_golem"
+						}
+					}
+				}
+			}
+		}
+	""".trimIndent()
+
 	advancement("player_killed_entity") {
 		criteria {
 			playerKilledEntity("player_killed_entity")

--- a/website/src/jsMain/resources/markdown/doc/data-driven/advancements/Triggers.md
+++ b/website/src/jsMain/resources/markdown/doc/data-driven/advancements/Triggers.md
@@ -5,7 +5,7 @@ nav-title: Advancements Triggers
 description: A guide for using advancements triggers in Minecraft with Kore.
 keywords: minecraft, datapack, kore, guide, advancements, triggers
 date-created: 2024-08-01
-date-modified: 2026-02-15
+date-modified: 2026-04-25
 routeOverride: /docs/data-driven/advancements/triggers
 ---
 
@@ -888,6 +888,33 @@ Triggers when a player hurts an entity.
 playerHurtEntity("hurt_mob") {
 	damage {
 		taken = rangeOrDouble(5.0..10.0)
+	}
+}
+```
+
+---
+
+### `playerInteractedWithEntity`
+
+**Description:**  
+Triggers when a player interacts with an entity.
+
+**Properties:**
+
+- `item`: The item used during the interaction.
+- `entity`: The entity that was interacted with.
+
+**Example:**
+
+```kotlin
+playerInteractedWithEntity("interact_with_golem") {
+	item {
+		items = listOf(Items.IRON_INGOT)
+	}
+	entity {
+		conditionEntity {
+			type(EntityTypes.IRON_GOLEM)
+		}
 	}
 }
 ```


### PR DESCRIPTION
## What changed
Implements the missing player_interacted_with_entity advancement trigger and added some tests.

I needed this feature urgently to continue my project, so I went ahead and implemented it. Please feel free to ignore this PR if it’s already included in your next release.

Test from Fandom Wiki example.